### PR TITLE
attempt to fix media sequence drift causing mediaIndex to go negative…

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -327,7 +327,7 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     // we reloaded the same playlist so we are in a live scenario
     // and we will likely need to adjust the mediaIndex
-    let mediaSequenceDiff = newPlaylist.mediaSequence - oldPlaylist.mediaSequence;
+    let mediaSequenceDiff = Math.min(newPlaylist.mediaSequence - oldPlaylist.mediaSequence, (oldPlaylist.segments.length - 1));
 
     this.logger_('mediaSequenceDiff', mediaSequenceDiff);
 

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -222,6 +222,12 @@ export default class SyncController extends videojs.EventTarget {
     // When a segment expires from the playlist and it has a start time
     // save that information as a possible sync-point reference in future
     for (let i = mediaSequenceDiff - 1; i >= 0; i--) {
+      
+      // mediaSequenceDiff might be larger than the old playlist !!!
+      if (i >= oldPlaylist.segments.length) {
+        continue;
+      }
+
       let lastRemovedSegment = oldPlaylist.segments[i];
 
       if (typeof lastRemovedSegment.start !== 'undefined') {


### PR DESCRIPTION
… + handling streams where diff is larger than previous playlist

all this sounds very broken from the stream perspective, but is possible!

## Description
Please describe the change as necessary.
If it's a feature or enhancement please be as detailed as possible.
If it's a bug fix, please link the issue that it fixes or describe the bug in as much detail.

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors
