### PR TITLE
Changes to PR 1210

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,7 +557,6 @@ will have this structure
 ```javascript
 cue.value = {
   byteLength, // The size of the segment in bytes
-  bitrate, // The bitrate calculated from byteLength, start, and end
   bandwidth, // The peak bitrate reported by the segment's playlist
   resolution, // The resolution reported by the segment's playlist
   codecs, // The codecs reported by the segment's playlist

--- a/README.md
+++ b/README.md
@@ -556,6 +556,11 @@ will have this structure
 
 ```javascript
 cue.value = {
+  byteLength, // The size of the segment in bytes
+  bitrate, // The bitrate calculated from byteLength, start, and end
+  bandwidth, // The peak bitrate reported by the segment's playlist
+  resolution, // The resolution reported by the segment's playlist
+  codecs, // The codecs reported by the segment's playlist
   uri, // The Segment uri
   timeline, // Timeline of the segment for detecting discontinuities
   playlist, // The Playlist uri

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1227,7 +1227,6 @@ export default class SegmentLoader extends videojs.EventTarget {
       bandwidth: segmentInfo.playlist.attributes.BANDWIDTH,
       resolution: segmentInfo.playlist.attributes.RESOLUTION,
       codecs: segmentInfo.playlist.attributes.CODECS,
-      bitrate: (8 * segmentInfo.byteLength / (end - start)),
       byteLength: segmentInfo.byteLength,
       uri: segmentInfo.uri,
       timeline: segmentInfo.timeline,

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1224,9 +1224,9 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     const Cue = window.WebKitDataCue || window.VTTCue;
     const value = {
-      bandwidth: segmentInfo.playlist.attributes['BANDWIDTH'],
-      resolution: segmentInfo.playlist.attributes['RESOLUTION'],
-      codecs: segmentInfo.playlist.attributes['CODECS'],
+      bandwidth: segmentInfo.playlist.attributes.BANDWIDTH,
+      resolution: segmentInfo.playlist.attributes.RESOLUTION,
+      codecs: segmentInfo.playlist.attributes.CODECS,
       bitrate: (8 * segmentInfo.byteLength / (end - start)),
       byteLength: segmentInfo.byteLength,
       uri: segmentInfo.uri,

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -299,8 +299,7 @@ QUnit.module('SegmentLoader', function(hooks) {
           bandwidth: 3500000,
           resolution: '1920x1080',
           codecs: 'mp4a.40.5,avc1.42001e',
-          byteLength: 10,
-          bitrate: 8.421052631578947
+          byteLength: 10
         };
 
         assert.equal(track.cues.length, 1, 'one cue added for segment');
@@ -321,8 +320,7 @@ QUnit.module('SegmentLoader', function(hooks) {
           bandwidth: 3500000,
           resolution: '1920x1080',
           codecs: 'mp4a.40.5,avc1.42001e',
-          byteLength: 10,
-          bitrate: 8.298755186721992
+          byteLength: 10
         };
 
         assert.equal(track.cues.length, 2, 'one cue added for segment');
@@ -343,8 +341,7 @@ QUnit.module('SegmentLoader', function(hooks) {
           bandwidth: 3500000,
           resolution: '1920x1080',
           codecs: 'mp4a.40.5,avc1.42001e',
-          byteLength: 10,
-          bitrate: 8.205128205128204
+          byteLength: 10
         };
 
         assert.equal(track.cues.length, 3, 'one cue added for segment');
@@ -367,8 +364,7 @@ QUnit.module('SegmentLoader', function(hooks) {
           bandwidth: 3500000,
           resolution: '1920x1080',
           codecs: 'mp4a.40.5,avc1.42001e',
-          byteLength: 10,
-          bitrate: 8.18833162743091
+          byteLength: 10
         };
 
         assert.equal(track.cues.length, 3, 'overlapped cue removed, new one added');

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -262,7 +262,12 @@ QUnit.module('SegmentLoader', function(hooks) {
                'as they are buffered',
       function(assert) {
         const track = loader.segmentMetadataTrack_;
-        let playlist = playlistWithDuration(50);
+        const attributes = {
+          BANDWIDTH: 3500000,
+          RESOLUTION: '1920x1080',
+          CODECS: 'mp4a.40.5,avc1.42001e'
+        };
+        let playlist = playlistWithDuration(50, {attributes});
         let probeResponse;
         let expectedCue;
 
@@ -290,7 +295,12 @@ QUnit.module('SegmentLoader', function(hooks) {
           timeline: 0,
           playlist: 'playlist.m3u8',
           start: 0,
-          end: 9.5
+          end: 9.5,
+          bandwidth: 3500000,
+          resolution: '1920x1080',
+          codecs: 'mp4a.40.5,avc1.42001e',
+          byteLength: 10,
+          bitrate: 8.421052631578947
         };
 
         assert.equal(track.cues.length, 1, 'one cue added for segment');
@@ -307,7 +317,12 @@ QUnit.module('SegmentLoader', function(hooks) {
           timeline: 0,
           playlist: 'playlist.m3u8',
           start: 9.56,
-          end: 19.2
+          end: 19.2,
+          bandwidth: 3500000,
+          resolution: '1920x1080',
+          codecs: 'mp4a.40.5,avc1.42001e',
+          byteLength: 10,
+          bitrate: 8.298755186721992
         };
 
         assert.equal(track.cues.length, 2, 'one cue added for segment');
@@ -324,7 +339,12 @@ QUnit.module('SegmentLoader', function(hooks) {
           timeline: 0,
           playlist: 'playlist.m3u8',
           start: 19.24,
-          end: 28.99
+          end: 28.99,
+          bandwidth: 3500000,
+          resolution: '1920x1080',
+          codecs: 'mp4a.40.5,avc1.42001e',
+          byteLength: 10,
+          bitrate: 8.205128205128204
         };
 
         assert.equal(track.cues.length, 3, 'one cue added for segment');
@@ -343,7 +363,12 @@ QUnit.module('SegmentLoader', function(hooks) {
           timeline: 0,
           playlist: 'playlist.m3u8',
           start: 19.21,
-          end: 28.98
+          end: 28.98,
+          bandwidth: 3500000,
+          resolution: '1920x1080',
+          codecs: 'mp4a.40.5,avc1.42001e',
+          byteLength: 10,
+          bitrate: 8.18833162743091
         };
 
         assert.equal(track.cues.length, 3, 'overlapped cue removed, new one added');

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -371,7 +371,7 @@ export const playlistWithDuration = function(time, conf) {
     uri: conf && typeof conf.uri !== 'undefined' ? conf.uri : 'playlist.m3u8',
     discontinuitySequence:
       conf && conf.discontinuitySequence ? conf.discontinuitySequence : 0,
-    attributes: {}
+    attributes: conf && typeof conf.attributes !== 'undefined' ? conf.attributes : {}
   };
   let count = Math.floor(time / 10);
   let remainder = time % 10;


### PR DESCRIPTION
Yo. I made the changes requested in [your PR](https://github.com/videojs/videojs-contrib-hls/pull/1210).

I'd like to know, though, is there a specific use case or debug reason you're adding the segment's "bitrate"? I could see annotations that report what you could handle (such as `hls.bandwidth` or `hls.throughput`) as being useful when collecting metrics, but I don't see how that specific measurement would tie in. Maybe I'm missing something.